### PR TITLE
Add riskCR

### DIFF
--- a/src/Size.sol
+++ b/src/Size.sol
@@ -123,7 +123,7 @@ contract Size is
     function withdraw(WithdrawParams calldata params) external override(ISize) whenNotPaused {
         state.validateWithdraw(params);
         state.executeWithdraw(params);
-        state.validateUserIsNotLiquidatable(msg.sender);
+        state.validateUserIsNotBelowRiskCR(msg.sender);
     }
 
     /// @inheritdoc ISize
@@ -142,7 +142,7 @@ contract Size is
     function lendAsMarketOrder(LendAsMarketOrderParams calldata params) external override(ISize) whenNotPaused {
         state.validateLendAsMarketOrder(params);
         state.executeLendAsMarketOrder(params);
-        state.validateUserIsNotLiquidatable(params.borrower);
+        state.validateUserIsNotBelowRiskCR(params.borrower);
         state.validateDebtTokenCap();
     }
 
@@ -150,7 +150,7 @@ contract Size is
     function borrowAsMarketOrder(BorrowAsMarketOrderParams memory params) external override(ISize) whenNotPaused {
         state.validateBorrowAsMarketOrder(params);
         state.executeBorrowAsMarketOrder(params);
-        state.validateUserIsNotLiquidatable(msg.sender);
+        state.validateUserIsNotBelowRiskCR(msg.sender);
         state.validateDebtTokenCap();
     }
 
@@ -158,7 +158,7 @@ contract Size is
     function borrowerExit(BorrowerExitParams calldata params) external override(ISize) whenNotPaused {
         state.validateBorrowerExit(params);
         state.executeBorrowerExit(params);
-        state.validateUserIsNotLiquidatable(params.borrowerToExitTo);
+        state.validateUserIsNotBelowRiskCR(params.borrowerToExitTo);
     }
 
     /// @inheritdoc ISize
@@ -204,7 +204,7 @@ contract Size is
         state.validateLiquidateFixedLoanWithReplacement(params);
         (liquidatorProfitCollateralAsset, liquidatorProfitBorrowAsset) =
             state.executeLiquidateFixedLoanWithReplacement(params);
-        state.validateUserIsNotLiquidatable(params.borrower);
+        state.validateUserIsNotBelowRiskCR(params.borrower);
     }
 
     /// @inheritdoc ISize

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -60,6 +60,9 @@ library Errors {
     error LOAN_NOT_LIQUIDATABLE(uint256 loanId, uint256 cr, FixedLoanStatus status);
     error LOAN_NOT_SELF_LIQUIDATABLE(uint256 loanId, uint256 cr, FixedLoanStatus status);
     error COLLATERAL_RATIO_BELOW_MINIMUM_COLLATERAL_RATIO(uint256 collateralRatio, uint256 minimumCollateralRatio);
+    error COLLATERAL_RATIO_BELOW_RISK_COLLATERAL_RATIO(
+        address account, uint256 collateralRatio, uint256 riskCollateralRatio
+    );
     error LIQUIDATION_NOT_AT_LOSS(uint256 loanId, uint256 assignedCollateral, uint256 debtCollateral);
 
     error INVALID_DECIMALS(uint8 decimals);

--- a/src/libraries/Math.sol
+++ b/src/libraries/Math.sol
@@ -10,6 +10,10 @@ library Math {
         return FixedPointMathLib.min(a, b);
     }
 
+    function max(uint256 a, uint256 b) internal pure returns (uint256) {
+        return FixedPointMathLib.max(a, b);
+    }
+
     function min(uint256 a, uint256 b, uint256 c) internal pure returns (uint256) {
         uint256 minAB = FixedPointMathLib.min(a, b);
         return FixedPointMathLib.min(minAB, c);

--- a/src/libraries/fixed/FixedLibrary.sol
+++ b/src/libraries/fixed/FixedLibrary.sol
@@ -186,9 +186,13 @@ library FixedLibrary {
         return collateralRatio(state, account) < state._fixed.crLiquidation;
     }
 
-    function validateUserIsNotLiquidatable(State storage state, address account) external view {
-        if (isUserLiquidatable(state, account)) {
-            revert Errors.USER_IS_LIQUIDATABLE(account, collateralRatio(state, account));
+    function validateUserIsNotBelowRiskCR(State storage state, address account) external view {
+        uint256 riskCR = Math.max(
+            state._fixed.crOpening,
+            state._fixed.users[account].borrowOffer.riskCR // 0 by default, or user-defined if BorrowAsLimitOrder has been placed
+        );
+        if (collateralRatio(state, account) < riskCR) {
+            revert Errors.COLLATERAL_RATIO_BELOW_RISK_COLLATERAL_RATIO(account, collateralRatio(state, account), riskCR);
         }
     }
 

--- a/src/libraries/fixed/OfferLibrary.sol
+++ b/src/libraries/fixed/OfferLibrary.sol
@@ -9,6 +9,7 @@ struct FixedLoanOffer {
 }
 
 struct BorrowOffer {
+    uint256 riskCR;
     YieldCurve curveRelativeTime;
 }
 

--- a/src/libraries/fixed/actions/BorrowAsLimitOrder.sol
+++ b/src/libraries/fixed/actions/BorrowAsLimitOrder.sol
@@ -8,6 +8,7 @@ import {YieldCurve, YieldCurveLibrary} from "@src/libraries/fixed/YieldCurveLibr
 import {Events} from "@src/libraries/Events.sol";
 
 struct BorrowAsLimitOrderParams {
+    uint256 riskCR;
     YieldCurve curveRelativeTime;
 }
 
@@ -15,12 +16,16 @@ library BorrowAsLimitOrder {
     function validateBorrowAsLimitOrder(State storage, BorrowAsLimitOrderParams calldata params) external pure {
         // validate msg.sender
 
+        // validate riskCR
+        // N/A
+
         // validate curveRelativeTime
         YieldCurveLibrary.validateYieldCurve(params.curveRelativeTime);
     }
 
     function executeBorrowAsLimitOrder(State storage state, BorrowAsLimitOrderParams calldata params) external {
-        state._fixed.users[msg.sender].borrowOffer = BorrowOffer({curveRelativeTime: params.curveRelativeTime});
+        state._fixed.users[msg.sender].borrowOffer =
+            BorrowOffer({riskCR: params.riskCR, curveRelativeTime: params.curveRelativeTime});
         emit Events.BorrowAsLimitOrder(params.curveRelativeTime);
     }
 }

--- a/src/libraries/variable/VariableLibrary.sol
+++ b/src/libraries/variable/VariableLibrary.sol
@@ -137,8 +137,4 @@ library VariableLibrary {
             state, loan.borrower, address(this), assignedCollateral - liquidatorProfitCollateralToken, loan.faceValue
         );
     }
-
-    function getMarketRate(State storage state) public view returns (uint256) {
-        return 0;
-    }
 }

--- a/test/BaseTestFixed.sol
+++ b/test/BaseTestFixed.sol
@@ -157,22 +157,19 @@ abstract contract BaseTestFixed is Test, BaseTestGeneral {
         return size.activeFixedLoans() > 0 ? size.activeFixedLoans() - 1 : type(uint256).max;
     }
 
-    function _borrowAsLimitOrder(
-        address borrower,
-        uint256[] memory timeBuckets,
-        uint256[] memory rates,
-        int256[] memory marketRateMultipliers
-    ) internal {
-        YieldCurve memory curveRelativeTime =
-            YieldCurve({timeBuckets: timeBuckets, marketRateMultipliers: marketRateMultipliers, rates: rates});
+    function _borrowAsLimitOrder(address borrower, YieldCurve memory curveRelativeTime) internal {
         vm.prank(borrower);
-        size.borrowAsLimitOrder(BorrowAsLimitOrderParams({curveRelativeTime: curveRelativeTime}));
+        size.borrowAsLimitOrder(BorrowAsLimitOrderParams({riskCR: 0, curveRelativeTime: curveRelativeTime}));
     }
 
     function _borrowAsLimitOrder(address borrower, uint256 rate, uint256 timeBucketsLength) internal {
         YieldCurve memory curveRelativeTime = YieldCurveHelper.getFlatRate(timeBucketsLength, rate);
+        return _borrowAsLimitOrder(borrower, 0, curveRelativeTime);
+    }
+
+    function _borrowAsLimitOrder(address borrower, uint256 riskCR, YieldCurve memory curveRelativeTime) internal {
         vm.prank(borrower);
-        size.borrowAsLimitOrder(BorrowAsLimitOrderParams({curveRelativeTime: curveRelativeTime}));
+        size.borrowAsLimitOrder(BorrowAsLimitOrderParams({riskCR: riskCR, curveRelativeTime: curveRelativeTime}));
     }
 
     function _lendAsMarketOrder(address lender, address borrower, uint256 amount, uint256 dueDate)

--- a/test/fixed/BorrowAsLimitOrder.t.sol
+++ b/test/fixed/BorrowAsLimitOrder.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.20;
 
+import {Errors} from "@src/libraries/Errors.sol";
+import {YieldCurve} from "@src/libraries/fixed/YieldCurveLibrary.sol";
 import {BaseTest} from "@test/BaseTest.sol";
 
 import {BorrowOffer, OfferLibrary} from "@src/libraries/fixed/OfferLibrary.sol";
@@ -18,14 +20,22 @@ contract BorrowAsLimitOrderTest is BaseTest {
         rates[0] = 1.01e18;
         rates[1] = 1.02e18;
         int256[] memory marketRateMultipliers = new int256[](2);
+        uint256 riskCR = 1.5e18;
         assertTrue(_state().alice.user.borrowOffer.isNull());
-        _borrowAsLimitOrder(alice, timeBuckets, rates, marketRateMultipliers);
+        _borrowAsLimitOrder(
+            alice,
+            riskCR,
+            YieldCurve({timeBuckets: timeBuckets, rates: rates, marketRateMultipliers: marketRateMultipliers})
+        );
+
         assertTrue(!_state().alice.user.borrowOffer.isNull());
     }
 
-    function test_BorrowAsLimitOrder_borrowAsLimitOrder_adds_borrowOffer_to_orderbook(uint256 buckets, bytes32 seed)
-        public
-    {
+    function test_BorrowAsLimitOrder_borrowAsLimitOrder_adds_borrowOffer_to_orderbook(
+        uint256 riskCR,
+        uint256 buckets,
+        bytes32 seed
+    ) public {
         buckets = bound(buckets, 1, 365);
         uint256[] memory timeBuckets = new uint256[](buckets);
         uint256[] memory rates = new uint256[](buckets);
@@ -35,6 +45,59 @@ contract BorrowAsLimitOrderTest is BaseTest {
             timeBuckets[i] = i * 1 days;
             rates[i] = bound(uint256(keccak256(abi.encode(seed, i))), 0, 10e18);
         }
-        _borrowAsLimitOrder(alice, timeBuckets, rates, marketRateMultipliers);
+        _borrowAsLimitOrder(
+            alice,
+            riskCR,
+            YieldCurve({timeBuckets: timeBuckets, rates: rates, marketRateMultipliers: marketRateMultipliers})
+        );
+    }
+
+    function test_BorrowAsLimitOrder_borrowAsLimitOrder_cant_be_placed_if_cr_is_below_riskCR() public {
+        _setPrice(1e18);
+        _deposit(bob, usdc, 100e6);
+        _deposit(alice, weth, 150e18);
+        uint256[] memory timeBuckets = new uint256[](2);
+        timeBuckets[0] = 1 days;
+        timeBuckets[1] = 2 days;
+        uint256[] memory rates = new uint256[](2);
+        rates[0] = 0e18;
+        rates[1] = 1e18;
+        int256[] memory marketRateMultipliers = new int256[](2);
+        uint256 riskCR = 1.7e18;
+        _borrowAsLimitOrder(
+            alice,
+            riskCR,
+            YieldCurve({timeBuckets: timeBuckets, rates: rates, marketRateMultipliers: marketRateMultipliers})
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.COLLATERAL_RATIO_BELOW_RISK_COLLATERAL_RATIO.selector, alice, 1.5e18, 1.7e18)
+        );
+        uint256 loanId = _lendAsMarketOrder(bob, alice, 100e6, block.timestamp + 1 days, true);
+    }
+
+    function test_BorrowAsLimitOrder_borrowAsLimitOrder_cant_be_placed_if_cr_is_below_crOpening_even_if_riskCR_is_below(
+    ) public {
+        _setPrice(1e18);
+        _deposit(bob, usdc, 100e6);
+        _deposit(alice, weth, 140e18);
+        uint256[] memory timeBuckets = new uint256[](2);
+        timeBuckets[0] = 1 days;
+        timeBuckets[1] = 2 days;
+        uint256[] memory rates = new uint256[](2);
+        rates[0] = 0e18;
+        rates[1] = 1e18;
+        int256[] memory marketRateMultipliers = new int256[](2);
+        uint256 riskCR = 1.3e18;
+        _borrowAsLimitOrder(
+            alice,
+            riskCR,
+            YieldCurve({timeBuckets: timeBuckets, rates: rates, marketRateMultipliers: marketRateMultipliers})
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.COLLATERAL_RATIO_BELOW_RISK_COLLATERAL_RATIO.selector, alice, 1.4e18, 1.5e18)
+        );
+        uint256 loanId = _lendAsMarketOrder(bob, alice, 100e6, block.timestamp + 1 days, true);
     }
 }

--- a/test/fixed/BorrowAsLimitOrderValidation.t.sol
+++ b/test/fixed/BorrowAsLimitOrderValidation.t.sol
@@ -15,7 +15,6 @@ contract BorrowAsLimitOrderValidationTest is BaseTest {
 
     function test_BorrowAsLimitOrder_validation() public {
         _deposit(alice, weth, 100e18);
-        uint256 maxAmount = 100e6;
         uint256[] memory timeBuckets = new uint256[](2);
         int256[] memory marketRateMultipliers = new int256[](2);
         timeBuckets[0] = 1 days;
@@ -26,6 +25,7 @@ contract BorrowAsLimitOrderValidationTest is BaseTest {
         vm.expectRevert(abi.encodeWithSelector(Errors.ARRAY_LENGTHS_MISMATCH.selector));
         size.borrowAsLimitOrder(
             BorrowAsLimitOrderParams({
+                riskCR: 0,
                 curveRelativeTime: YieldCurve({
                     timeBuckets: timeBuckets,
                     marketRateMultipliers: marketRateMultipliers,
@@ -39,6 +39,7 @@ contract BorrowAsLimitOrderValidationTest is BaseTest {
         vm.expectRevert(abi.encodeWithSelector(Errors.NULL_ARRAY.selector));
         size.borrowAsLimitOrder(
             BorrowAsLimitOrderParams({
+                riskCR: 0,
                 curveRelativeTime: YieldCurve({
                     timeBuckets: timeBuckets,
                     marketRateMultipliers: marketRateMultipliers,
@@ -56,6 +57,7 @@ contract BorrowAsLimitOrderValidationTest is BaseTest {
         vm.expectRevert(abi.encodeWithSelector(Errors.TIME_BUCKETS_NOT_STRICTLY_INCREASING.selector));
         size.borrowAsLimitOrder(
             BorrowAsLimitOrderParams({
+                riskCR: 0,
                 curveRelativeTime: YieldCurve({
                     timeBuckets: timeBuckets,
                     marketRateMultipliers: marketRateMultipliers,

--- a/test/fixed/BorrowAsMarketOrder.t.sol
+++ b/test/fixed/BorrowAsMarketOrder.t.sol
@@ -33,7 +33,6 @@ contract BorrowAsMarketOrderTest is BaseTest {
         _deposit(bob, weth, 100e18);
         _deposit(bob, usdc, 100e6);
         _lendAsLimitOrder(alice, 12, 0.03e18, 12);
-        FixedLoanOffer memory offerBefore = size.getUserView(alice).user.loanOffer;
 
         Vars memory _before = _state();
 
@@ -47,7 +46,6 @@ contract BorrowAsMarketOrderTest is BaseTest {
         uint256 debtOpeningWad = ConversionLibrary.amountToWad(debtOpening, usdc.decimals());
         uint256 minimumCollateral = Math.mulDivUp(debtOpeningWad, 10 ** priceFeed.decimals(), priceFeed.getPrice());
         Vars memory _after = _state();
-        FixedLoanOffer memory offerAfter = size.getUserView(alice).user.loanOffer;
 
         assertGt(_before.bob.collateralAmount, minimumCollateral);
         assertEq(_after.alice.borrowAmount, _before.alice.borrowAmount - amount);
@@ -75,7 +73,6 @@ contract BorrowAsMarketOrderTest is BaseTest {
         _deposit(bob, usdc, MAX_AMOUNT_USDC);
 
         _lendAsLimitOrder(alice, block.timestamp + MAX_DUE_DATE, rate, MAX_DUE_DATE);
-        FixedLoanOffer memory offerBefore = size.getUserView(alice).user.loanOffer;
 
         Vars memory _before = _state();
 
@@ -85,7 +82,6 @@ contract BorrowAsMarketOrderTest is BaseTest {
         uint256 debtOpeningWad = ConversionLibrary.amountToWad(debtOpening, usdc.decimals());
         uint256 minimumCollateral = Math.mulDivUp(debtOpeningWad, 10 ** priceFeed.decimals(), priceFeed.getPrice());
         Vars memory _after = _state();
-        FixedLoanOffer memory offerAfter = size.getUserView(alice).user.loanOffer;
 
         assertGt(_before.bob.collateralAmount, minimumCollateral);
         assertEq(_after.alice.borrowAmount, _before.alice.borrowAmount - amount);

--- a/test/fixed/BorrowerExit.t.sol
+++ b/test/fixed/BorrowerExit.t.sol
@@ -6,7 +6,6 @@ import {Vars} from "@test/BaseTestGeneral.sol";
 
 import {Errors} from "@src/libraries/Errors.sol";
 import {FixedLoan} from "@src/libraries/fixed/FixedLoanLibrary.sol";
-import {BorrowOffer} from "@src/libraries/fixed/OfferLibrary.sol";
 import {BorrowerExitParams} from "@src/libraries/fixed/actions/BorrowerExit.sol";
 
 contract BorrowerExitTest is BaseTest {
@@ -23,13 +22,11 @@ contract BorrowerExitTest is BaseTest {
 
         Vars memory _before = _state();
 
-        BorrowOffer memory borrowOfferBefore = size.getUserView(candy).user.borrowOffer;
         FixedLoan memory loanBefore = size.getFixedLoan(loanId);
         uint256 loansBefore = size.activeFixedLoans();
 
         _borrowerExit(bob, loanId, candy);
 
-        BorrowOffer memory borrowOfferAfter = size.getUserView(candy).user.borrowOffer;
         FixedLoan memory loanAfter = size.getFixedLoan(loanId);
         uint256 loansAfter = size.activeFixedLoans();
 
@@ -60,13 +57,11 @@ contract BorrowerExitTest is BaseTest {
 
         address borrowerToExitTo = bob;
 
-        BorrowOffer memory borrowOfferBefore = size.getUserView(bob).user.borrowOffer;
         FixedLoan memory loanBefore = size.getFixedLoan(loanId);
         uint256 loansBefore = size.activeFixedLoans();
 
         _borrowerExit(bob, loanId, borrowerToExitTo);
 
-        BorrowOffer memory borrowOfferAfter = size.getUserView(bob).user.borrowOffer;
         FixedLoan memory loanAfter = size.getFixedLoan(loanId);
         uint256 loansAfter = size.activeFixedLoans();
 
@@ -89,7 +84,11 @@ contract BorrowerExitTest is BaseTest {
         _borrowAsLimitOrder(candy, 0, 12);
 
         vm.startPrank(bob);
-        vm.expectRevert(abi.encodeWithSelector(Errors.USER_IS_LIQUIDATABLE.selector, candy, 1.5e18 / 2));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.COLLATERAL_RATIO_BELOW_RISK_COLLATERAL_RATIO.selector, candy, 1.5e18 / 2, 1.5e18
+            )
+        );
         size.borrowerExit(BorrowerExitParams({loanId: loanId, borrowerToExitTo: candy}));
     }
 }

--- a/test/fixed/LendAsMarketOrder.t.sol
+++ b/test/fixed/LendAsMarketOrder.t.sol
@@ -32,14 +32,12 @@ contract LendAsMarketOrderTest is BaseTest {
         uint256 amountIn = Math.mulDivUp(faceValue, PERCENT, PERCENT + 0.03e18);
 
         Vars memory _before = _state();
-        BorrowOffer memory offerBefore = size.getUserView(alice).user.borrowOffer;
         uint256 loansBefore = size.activeFixedLoans();
 
         uint256 loanId = _lendAsMarketOrder(bob, alice, faceValue, dueDate);
         FixedLoan memory loan = size.getFixedLoan(loanId);
 
         Vars memory _after = _state();
-        BorrowOffer memory offerAfter = size.getUserView(alice).user.borrowOffer;
         uint256 loansAfter = size.activeFixedLoans();
 
         assertEq(_after.alice.borrowAmount, _before.alice.borrowAmount + amountIn);
@@ -63,14 +61,12 @@ contract LendAsMarketOrderTest is BaseTest {
         uint256 faceValue = Math.mulDivDown(amountIn, PERCENT + 0.03e18, PERCENT);
 
         Vars memory _before = _state();
-        BorrowOffer memory offerBefore = size.getUserView(alice).user.borrowOffer;
         uint256 loansBefore = size.activeFixedLoans();
 
         uint256 loanId = _lendAsMarketOrder(bob, alice, amountIn, dueDate, true);
         FixedLoan memory loan = size.getFixedLoan(loanId);
 
         Vars memory _after = _state();
-        BorrowOffer memory offerAfter = size.getUserView(alice).user.borrowOffer;
         uint256 loansAfter = size.activeFixedLoans();
 
         assertEq(_after.alice.borrowAmount, _before.alice.borrowAmount + amountIn);
@@ -88,7 +84,7 @@ contract LendAsMarketOrderTest is BaseTest {
         _deposit(bob, weth, 100e18);
         _deposit(bob, usdc, 100e6);
         YieldCurve memory curve = YieldCurveHelper.getRandomYieldCurve(seed);
-        _borrowAsLimitOrder(alice, curve.timeBuckets, curve.rates, curve.marketRateMultipliers);
+        _borrowAsLimitOrder(alice, curve);
 
         amountIn = bound(amountIn, 5e6, 100e6);
         uint256 dueDate = block.timestamp + (curve.timeBuckets[0] + curve.timeBuckets[1]) / 2;
@@ -96,14 +92,12 @@ contract LendAsMarketOrderTest is BaseTest {
         uint256 faceValue = Math.mulDivDown(amountIn, r, PERCENT);
 
         Vars memory _before = _state();
-        BorrowOffer memory offerBefore = size.getUserView(alice).user.borrowOffer;
         uint256 loansBefore = size.activeFixedLoans();
 
         uint256 loanId = _lendAsMarketOrder(bob, alice, amountIn, dueDate, true);
         FixedLoan memory loan = size.getFixedLoan(loanId);
 
         Vars memory _after = _state();
-        BorrowOffer memory offerAfter = size.getUserView(alice).user.borrowOffer;
         uint256 loansAfter = size.activeFixedLoans();
 
         assertEq(_after.alice.borrowAmount, _before.alice.borrowAmount + amountIn);
@@ -122,7 +116,11 @@ contract LendAsMarketOrderTest is BaseTest {
         _borrowAsLimitOrder(alice, 0, 12);
 
         vm.startPrank(bob);
-        vm.expectRevert(abi.encodeWithSelector(Errors.USER_IS_LIQUIDATABLE.selector, alice, 1.5e18 / 2));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.COLLATERAL_RATIO_BELOW_RISK_COLLATERAL_RATIO.selector, alice, 1.5e18 / 2, 1.5e18
+            )
+        );
         size.lendAsMarketOrder(
             LendAsMarketOrderParams({borrower: alice, dueDate: 12, amount: 200e6, exactAmountIn: false})
         );
@@ -149,7 +147,7 @@ contract LendAsMarketOrderTest is BaseTest {
         _deposit(alice, weth, 150e18);
         _deposit(bob, usdc, 200e6);
         YieldCurve memory curve = YieldCurveHelper.normalCurve();
-        _borrowAsLimitOrder(alice, curve.timeBuckets, curve.rates, curve.marketRateMultipliers);
+        _borrowAsLimitOrder(alice, curve);
 
         vm.startPrank(bob);
         vm.expectRevert(abi.encodeWithSelector(Errors.DUE_DATE_OUT_OF_RANGE.selector, 6 days, 30 days, 150 days));

--- a/test/fixed/LiquidateFixedLoanWithReplacement.t.sol
+++ b/test/fixed/LiquidateFixedLoanWithReplacement.t.sol
@@ -40,7 +40,6 @@ contract LiquidateFixedLoanWithReplacementTest is BaseTest {
 
         _setPrice(0.2e18);
 
-        BorrowOffer memory borrowOfferBefore = size.getUserView(candy).user.borrowOffer;
         FixedLoan memory loanBefore = size.getFixedLoan(loanId);
         Vars memory _before = _state();
 
@@ -50,7 +49,6 @@ contract LiquidateFixedLoanWithReplacementTest is BaseTest {
 
         _liquidateFixedLoanWithReplacement(liquidator, loanId, candy);
 
-        BorrowOffer memory borrowOfferAfter = size.getUserView(candy).user.borrowOffer;
         FixedLoan memory loanAfter = size.getFixedLoan(loanId);
         Vars memory _after = _state();
 
@@ -85,7 +83,6 @@ contract LiquidateFixedLoanWithReplacementTest is BaseTest {
 
         _setPrice(0.2e18);
 
-        BorrowOffer memory borrowOfferBefore = size.getUserView(candy).user.borrowOffer;
         FixedLoan memory loanBefore = size.getFixedLoan(loanId);
         Vars memory _before = _state();
 
@@ -95,7 +92,6 @@ contract LiquidateFixedLoanWithReplacementTest is BaseTest {
 
         _liquidateFixedLoanWithReplacement(liquidator, loanId, candy);
 
-        BorrowOffer memory borrowOfferAfter = size.getUserView(candy).user.borrowOffer;
         FixedLoan memory loanAfter = size.getFixedLoan(loanId);
         Vars memory _after = _state();
 
@@ -127,7 +123,9 @@ contract LiquidateFixedLoanWithReplacementTest is BaseTest {
 
         vm.startPrank(liquidator);
 
-        vm.expectRevert(abi.encodeWithSelector(Errors.USER_IS_LIQUIDATABLE.selector, candy, 0));
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.COLLATERAL_RATIO_BELOW_RISK_COLLATERAL_RATIO.selector, candy, 0, 1.5e18)
+        );
         size.liquidateFixedLoanWithReplacement(
             LiquidateFixedLoanWithReplacementParams({loanId: loanId, borrower: candy, minimumCollateralRatio: 1e18})
         );

--- a/test/fixed/Withdraw.t.sol
+++ b/test/fixed/Withdraw.t.sol
@@ -94,11 +94,15 @@ contract WithdrawTest is BaseTest {
         _borrowAsMarketOrder(bob, alice, 100e6, 12);
 
         vm.startPrank(bob);
-        vm.expectRevert(abi.encodeWithSelector(Errors.USER_IS_LIQUIDATABLE.selector, bob, 0));
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.COLLATERAL_RATIO_BELOW_RISK_COLLATERAL_RATIO.selector, bob, 0, 1.5e18)
+        );
         size.withdraw(WithdrawParams({token: address(weth), amount: 150e18, to: bob}));
 
         vm.startPrank(bob);
-        vm.expectRevert(abi.encodeWithSelector(Errors.USER_IS_LIQUIDATABLE.selector, bob, 0.01e18));
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.COLLATERAL_RATIO_BELOW_RISK_COLLATERAL_RATIO.selector, bob, 0.01e18, 1.5e18)
+        );
         size.withdraw(WithdrawParams({token: address(weth), amount: 149e18, to: bob}));
     }
 

--- a/test/invariants/TargetFunctions.sol
+++ b/test/invariants/TargetFunctions.sol
@@ -145,7 +145,7 @@ abstract contract TargetFunctions is Deploy, Helper, Properties, BaseTargetFunct
         YieldCurve memory curveRelativeTime = _getRandomYieldCurve(yieldCurveSeed);
 
         hevm.prank(sender);
-        size.borrowAsLimitOrder(BorrowAsLimitOrderParams({curveRelativeTime: curveRelativeTime}));
+        size.borrowAsLimitOrder(BorrowAsLimitOrderParams({riskCR: 0, curveRelativeTime: curveRelativeTime}));
 
         __after();
     }


### PR DESCRIPTION
Upon `borrowAsLimitOrder`, the borrower passes a `riskCR`, that is checked when lender picks their borrow order. The pick cannot leave the borrower with `CR < riskCR`, which defaults to `crOpening`
