### PR TITLE
v1.7 fixes depositOnBehalf of `msg.value` issue when `msg.sender != onBehalfOf`

### DIFF
--- a/src/market/libraries/actions/Deposit.sol
+++ b/src/market/libraries/actions/Deposit.sol
@@ -54,7 +54,10 @@ library Deposit {
         }
 
         // validate msg.value
-        if (msg.value != 0 && (msg.value != params.amount || params.token != address(state.data.weth))) {
+        if (
+            msg.value != 0
+                && (msg.value != params.amount || params.token != address(state.data.weth) || onBehalfOf != msg.sender)
+        ) {
             revert Errors.INVALID_MSG_VALUE(msg.value);
         }
 


### PR DESCRIPTION
# Description

Fixes https://cantina.xyz/code/d88cb915-64c9-4488-8062-dd16ede7a4a0/findings/52

> When msg.value is non-zero in an operator's depositOnBehalf call, the function deposits the caller's ETH instead of the onBehalfOf member's WETH into the Size market. This results in the loss of the operator's funds.

> This issue can occur in a multicall context, where the operator is also a user of Size and combines their deposit call with a depositOnBehalfOf call.

# Note to auditors

Although the recommendation of the auditor was to split `deposit` into an ERC-20 and a native-token `depositETH` function, we chose to simply block `onBehalfOf` deposits of `msg.value` if the delegator is not the `msg.sender`. This should fix the underlying issue, which is: although you can delegate to an operator the transfer of your ERC-20 tokens on your behalf, you cannot delegate the transfer of your ETH. By blocking delegated transfers of ETH, the root cause should be completely mitigated. Please verify that this is the case.