### PR TITLE
Add HTML coverage report artifacts to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,17 @@ jobs:
         run: |
           forge coverage --no-match-coverage "(script|test|deprecated)" --report lcov
 
+      - name: Generate HTML Coverage Report
+        run: |
+          genhtml lcov.info -o report --branch-coverage --ignore-errors inconsistent,corrupt
+
+      - name: Upload HTML Coverage Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: report/
+          retention-days: 30
+
       - name: Coveralls
         uses: coverallsapp/github-action@v2
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # size-solidity [![Coverage Status](https://coveralls.io/repos/github/SizeCredit/size-solidity/badge.svg?branch=main)](https://coveralls.io/github/SizeCredit/size-solidity?branch=main)
 
+## Coverage Reports
+
+- **Latest HTML Coverage Report**: [Download from GitHub Actions](https://github.com/SizeCredit/size-solidity/actions/workflows/ci.yml) (look for "coverage-report" artifact in the latest run)
+- **Interactive Coverage Dashboard**: [Coveralls](https://coveralls.io/github/SizeCredit/size-solidity?branch=main)
+
 <a href="https://github.com/SizeLending/size-solidity/raw/main/size.png"><img src="https://github.com/SizeLending/size-solidity/raw/main/size.png" width="300" alt="Size"/></a>
 
 Size is a credit marketplace with unified liquidity across maturities.


### PR DESCRIPTION
## Summary
- Add HTML coverage report generation and artifact upload to CI workflow
- Update README with links to downloadable coverage reports and Coveralls dashboard

## Changes
- **CI Enhancement**: Modified `.github/workflows/ci.yml` to generate HTML coverage reports using `genhtml`
- **Artifact Upload**: Added step to upload coverage reports as GitHub Actions artifacts with 30-day retention
- **Documentation**: Updated README with new "Coverage Reports" section providing easy access to both downloadable HTML reports and interactive Coveralls dashboard

## Test plan
- [x] Verify CI workflow generates HTML coverage reports using genhtml
- [x] Confirm artifacts are uploaded with 30-day retention
- [x] Test that README links provide clear access to coverage information
- [x] Ensure existing Coveralls integration remains functional

## Benefits
- Developers can now download detailed HTML coverage reports from GitHub Actions
- Browser-viewable coverage reports with line-by-line analysis
- Maintains existing Coveralls integration for online viewing
- 30-day artifact retention for historical coverage access

🤖 Generated with [Claude Code](https://claude.ai/code)