### PR TITLE
implement halmos test balance intergrity

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -43,3 +43,6 @@
 [submodule "lib/openzeppelin-contracts-upgradeable"]
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/openzeppelin/openzeppelin-contracts-upgradeable
+[submodule "lib/halmos-helpers-lib"]
+	path = lib/halmos-helpers-lib
+	url = https://github.com/igorganich/halmos-helpers-lib.git

--- a/remappings.txt
+++ b/remappings.txt
@@ -16,3 +16,4 @@ halmos-cheatcodes=lib/halmos-cheatcodes/src
 @tenderly-utils/=lib/tenderly-utils/src/
 @safe-utils/=lib/safe-utils/src/
 @ERC-7540-Reference/=lib/ERC-7540-Reference/
+halmos-helpers-lib/=lib/halmos-helpers-lib/src/

--- a/src/market/token/NonTransferrableRebasingTokenVault.sol
+++ b/src/market/token/NonTransferrableRebasingTokenVault.sol
@@ -310,7 +310,7 @@ contract NonTransferrableRebasingTokenVault is
 
     /// @notice Sets the shares of a user
     /// @dev Only callable by the adapter
-    function setSharesOf(address user, uint256 shares) public onlyAdapter {
+    function setSharesOf(address user, uint256 shares) virtual public onlyAdapter {
         sharesOf[user] = shares;
     }
 

--- a/test/halmos-test/HalmosSizeTest.sol
+++ b/test/halmos-test/HalmosSizeTest.sol
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.23;
+
+import "halmos-helpers-lib/HalmosHelpers.sol";
+
+import {Action, Authorization} from "@src/factory/libraries/Authorization.sol";
+import {Size} from "@src/market/Size.sol";
+import {ISize} from "@src/market/interfaces/ISize.sol";
+import "@test/mocks/PoolMock.sol";
+import {SizeFactory} from "@src/factory/SizeFactory.sol";
+import {ISizeFactory} from "@src/factory/interfaces/ISizeFactory.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {PriceFeedMock} from "@test/mocks/PriceFeedMock.sol";
+import "@test/mocks/USDC.sol";
+import "@test/mocks/NonTransferrableRebasingTokenVaultMock.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {
+    Initialize,
+    InitializeDataParams,
+    InitializeFeeConfigParams,
+    InitializeOracleParams,
+    InitializeRiskConfigParams
+} from "@src/market/libraries/actions/Initialize.sol";
+import {ERC4626Adapter} from "@src/market/token/adapters/ERC4626Adapter.sol";
+import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import {MockERC4626 as ERC4626Solady} from "@solady/test/utils/mocks/MockERC4626.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {DataView} from "@src/market/SizeViewData.sol";
+import {WETH} from "@test/mocks/WETH.sol";
+import {DepositParams} from "@src/market/libraries/actions/Deposit.sol";
+import {IPriceFeed} from "@src/oracle/IPriceFeed.sol";
+
+import {PriceFeed, PriceFeedParams} from "@src/oracle/v1.5.1/PriceFeed.sol";
+
+import {PriceFeedMock} from "@test/mocks/PriceFeedMock.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {AaveAdapter} from "@src/market/token/adapters/AaveAdapter.sol";
+import "@src/market/token/NonTransferrableRebasingTokenVault.sol";
+
+contract HalmosSizeTest is Test, HalmosHelpers {
+
+    uint256 private constant USDC_INITIAL_BALANCE = 1_000_000e6;
+    address deployer = address(0xcafe0000);
+    address feeRecipient = address(0xcafe0001);
+
+    SizeFactory internal sizeFactory;
+    address internal implementation;
+    IERC20Metadata internal collateral;
+    PriceFeedMock internal priceFeed;
+    InitializeFeeConfigParams internal f;
+    InitializeRiskConfigParams internal r;
+    InitializeOracleParams internal o;
+    InitializeDataParams internal d;
+    USDC private usdc;
+    WETH internal weth;
+    ERC4626Adapter erc4626Adapter;
+    IERC4626 internal vaultSolady;
+    ERC1967Proxy internal proxy;
+    AaveAdapter private aaveAdapter;
+
+    Size internal size;
+    NonTransferrableRebasingTokenVaultMock private token;
+    IPool private variablePool;
+
+    SymbolicActor[] vaults;
+    SymbolicActor[] actors;
+
+    address alice;
+    address bob;
+
+    address symbolic_vault;
+
+    constructor() {}
+
+    function setUp() external {
+        settingUp();
+    }
+
+    function settingUp() internal {
+        vm.startPrank(getConfigurer());
+        halmosHelpersInitialize();
+        // Don't process callbacks symbolically during setup
+        halmosHelpersSetSymbolicCallbacksDepth(0, 0);
+        /*
+        * Initialize 2 Actors
+        * actors[0] is a regular user
+        * actors[1] is a regular user
+        */
+        actors = halmosHelpersGetSymbolicActorArray(2);
+        /* vault can have any implementation. Therefore we use a symbolic handler as a vault */
+        vaults = halmosHelpersGetSymbolicActorArray(1);
+
+        alice = address(actors[0]);
+        bob = address(actors[1]);
+        symbolic_vault = address(vaults[0]);
+
+        vm.stopPrank();
+
+        vm.startPrank(deployer);
+
+        collateral = IERC20Metadata(address(new ERC20Mock()));
+        priceFeed = new PriceFeedMock(deployer);
+        priceFeed.setPrice(1e18);
+        weth = new WETH();
+        usdc = new USDC(deployer);
+        usdc.mint(address(alice), USDC_INITIAL_BALANCE);
+        usdc.mint(address(bob), USDC_INITIAL_BALANCE);
+        variablePool = IPool(address(new PoolMock()));
+        
+        token = new NonTransferrableRebasingTokenVaultMock();
+        sizeFactory = SizeFactory(address(new ERC1967Proxy(address(new SizeFactory()), abi.encodeCall(SizeFactory.initialize, (deployer)))));
+        token.initialize(
+            ISizeFactory(address(sizeFactory)),
+            variablePool,
+            usdc,
+            address(deployer),
+            string.concat("Size ", usdc.name(), " Vault"),
+            string.concat("sv", usdc.symbol()),
+            usdc.decimals()
+        );
+
+        f = InitializeFeeConfigParams({
+            swapFeeAPR: 0.005e18,
+            fragmentationFee: 5e6,
+            liquidationRewardPercent: 0.05e18,
+            overdueCollateralProtocolPercent: 0.01e18,
+            collateralProtocolPercent: 0.1e18,
+            feeRecipient: feeRecipient
+        });
+        r = InitializeRiskConfigParams({
+            crOpening: 1.5e18,
+            crLiquidation: 1.3e18,
+            minimumCreditBorrowToken: 5e6,
+            minTenor: 1 hours,
+            maxTenor: 5 * 365 days
+        });
+        o = InitializeOracleParams({priceFeed: address(priceFeed), variablePoolBorrowRateStaleRateInterval: 0});
+        d = InitializeDataParams({
+            weth: address(weth),
+            underlyingCollateralToken: address(weth),
+            underlyingBorrowToken: address(usdc),
+            variablePool: address(variablePool), // Aave v3
+            borrowTokenVault: address(token),
+            sizeFactory: address(sizeFactory)
+        });
+
+        implementation = address(new Size());
+        sizeFactory.setSizeImplementation(implementation);
+        proxy = ERC1967Proxy(payable(address(sizeFactory.createMarket(f, r, o, d))));
+        size = Size(payable(proxy));
+        PriceFeedMock(address(priceFeed)).setPrice(1337e18);
+
+        erc4626Adapter = new ERC4626Adapter(token, usdc);
+        token.setAdapter(bytes32("ERC4626Adapter"), erc4626Adapter);
+        aaveAdapter = new AaveAdapter(token, variablePool, usdc);
+        token.setAdapter(bytes32("AaveAdapter"), aaveAdapter);
+        token.setVaultAdapter(DEFAULT_VAULT, bytes32("AaveAdapter"));
+        token.setVaultAdapter(symbolic_vault, bytes32("ERC4626Adapter"));
+        vaultSolady = IERC4626(address(new ERC4626Solady(address(usdc), "VaultSolady", "VAULTSOLADY", true, 0)));
+        token.setVaultAdapter(address(vaultSolady), bytes32("ERC4626Adapter"));
+
+        vm.stopPrank();
+
+        vm.startPrank(address(size));
+        token.setVault(alice, symbolic_vault);
+        token.setVault(bob, address(vaultSolady));
+        vm.stopPrank();
+
+        /* 
+        * Deposit something and leave something on actors' balances, while everything is approved
+        * to cover more scenarios 
+        */
+        vm.startPrank(alice);
+        usdc.approve(address(size), USDC_INITIAL_BALANCE);
+        size.deposit(DepositParams({token: address(usdc), amount: USDC_INITIAL_BALANCE / 2, to: alice}));
+        sizeFactory.setAuthorization(address(size), Authorization.getActionsBitmap(Action.SET_USER_CONFIGURATION));
+        sizeFactory.setAuthorization(symbolic_vault, Authorization.getActionsBitmap(Action.SET_USER_CONFIGURATION));
+        vm.stopPrank();
+        // Symbolic implementation of vault can "forget" to take approved assets
+        vm.prank(address(vaults[0]));
+        usdc.transferFrom(address(erc4626Adapter), address(symbolic_vault), USDC_INITIAL_BALANCE / 2);
+
+        vm.startPrank(bob);
+        usdc.approve(address(size), USDC_INITIAL_BALANCE);
+        size.deposit(DepositParams({token: address(usdc), amount: USDC_INITIAL_BALANCE / 2, to: bob}));
+        sizeFactory.setAuthorization(address(size), Authorization.getActionsBitmap(Action.SET_USER_CONFIGURATION));
+        vm.stopPrank();
+
+        vm.startPrank(getConfigurer());
+        halmosHelpersRegisterTargetAddress(address(size), "Size");
+        /* 
+        * heuristics: multicall causes path explosion and doesn't create any new coverage.
+        * So I've decided to exclude this function from invariant testing.
+        * TODO: enable this selector when halmos-helpers will support optimized delegatecalls handling
+        */
+        halmosHelpersBanFunctionSelector(size.multicall.selector);
+        vm.stopPrank();
+    }
+
+    /* Should find 3.1.1 (No reentrancy required) */
+    function check_BalanceIntegrityNoReentrancy() external {
+        //vm.startPrank(getConfigurer());
+        // halmosHelpersSetOnlyAllowedSelectors(true);
+        // halmosHelpersAllowFunctionSelector(size.setUserConfigurationOnBehalfOf.selector);
+        //vm.stopPrank();
+
+        halmosHelpersSymbolicBatchStartPrank(actors);
+        executeSymbolicallyAllTargets("check_balanceIntegritySize");
+        vm.stopPrank();
+
+        vaultSoladyBalanceNotBrokenInvarint();
+    }
+    
+    /* Should find 3.1.1 and 3.3.2. Long test */
+    function check_BalanceIntegrityWithReentrancyNoDuplicateCallsDisabled() external {
+        vm.startPrank(getConfigurer());
+        // halmosHelpersSetOnlyAllowedSelectors(true);
+        // halmosHelpersAllowFunctionSelector(size.deposit.selector);
+        // halmosHelpersAllowFunctionSelector(size.setUserConfigurationOnBehalfOf.selector);
+        /* Process callbacks of depth 1 */
+        halmosHelpersSetSymbolicCallbacksDepth(1, 1);
+        vm.stopPrank();
+
+        halmosHelpersSymbolicBatchStartPrank(actors);
+        executeSymbolicallyAllTargets("check_balanceIntegritySize");
+        vm.stopPrank();
+
+        vaultSoladyBalanceNotBrokenInvarint();
+    }
+
+    /* Should find 3.1.1 and 3.3.2. Test is still pretty long but shorter than check_BalanceIntegrityWithReentrancyNoDuplicateCallsDisabled */
+    function check_BalanceIntegrityWithReentrancyNoDuplicateCallsEnabled() external {
+        vm.startPrank(getConfigurer());
+        //halmosHelpersSetOnlyAllowedSelectors(true);
+        //halmosHelpersAllowFunctionSelector(size.deposit.selector);
+        //halmosHelpersAllowFunctionSelector(size.setUserConfigurationOnBehalfOf.selector);
+        
+        /* Process callbacks of depth 1 */
+        halmosHelpersSetSymbolicCallbacksDepth(1, 1);
+        halmosHelpersSetNoDuplicateCalls(true);
+        vm.stopPrank();
+
+        halmosHelpersSymbolicBatchStartPrank(actors);
+        executeSymbolicallyAllTargets("check_balanceIntegritySize");
+        vm.stopPrank();
+
+        vaultSoladyBalanceNotBrokenInvarint();
+    }
+
+    /* 
+    * Theoretically, this test should find 3.1.1 and 3.3.2 in all forms (via reentrancy and trivially) in some time. 
+    * However, given that we have a lot of targets, there is no certainty that this test will be completed even in six months.
+    * It is also necessary to investigate all symbolic execution bottlenecks in these contracts and handle them.
+    * It should be perceived as just a way to expand the scenarios for testing, not an actual test to run.
+    */
+    function check_BalanceIntegrityFull() external {
+        vm.startPrank(getConfigurer());
+        halmosHelpersSetSymbolicCallbacksDepth(2, 2);
+        for (uint i = 0; i < actors.length; i++) {
+            actors[i].setSymbolicFallbackTxsNumber(2);
+            actors[i].setSymbolicReceiveTxsNumber(2);
+        }
+        for (uint i = 0; i < vaults.length; i++) {
+            actors[i].setSymbolicFallbackTxsNumber(2);
+            actors[i].setSymbolicReceiveTxsNumber(2);
+        }
+        halmosHelpersRegisterTargetAddress(address(collateral), "ERC20Mock");
+        halmosHelpersRegisterTargetAddress(address(priceFeed), "PriceFeedMock");
+        halmosHelpersRegisterTargetAddress(address(weth), "ERC20Mock");
+        halmosHelpersRegisterTargetAddress(address(usdc), "WETH");
+        halmosHelpersRegisterTargetAddress(address(variablePool), "IPool");
+        halmosHelpersRegisterTargetAddress(address(token), "NonTransferrableRebasingTokenVault");
+        halmosHelpersRegisterTargetAddress(address(sizeFactory), "SizeFactory");
+        halmosHelpersRegisterTargetAddress(address(implementation), "Size");
+        halmosHelpersRegisterTargetAddress(address(erc4626Adapter), "ERC4626Adapter");
+        halmosHelpersRegisterTargetAddress(address(aaveAdapter), "AaveAdapter");
+        halmosHelpersRegisterTargetAddress(address(vaultSolady), "IERC4626");
+        halmosHelpersRegisterTargetAddress(symbolic_vault, "SymbolicActor");
+        halmosHelpersRegisterTargetAddress(address(proxy), "ERC1967Proxy");
+        halmosHelpersRegisterTargetAddress(address(collateral), "ERC20Mock");
+
+        vm.stopPrank();
+
+        halmosHelpersSymbolicBatchStartPrank(actors);
+        executeSymbolicallyAllTargets("check_balanceIntegrityFull_1");
+        vm.stopPrank();
+
+        halmosHelpersSymbolicBatchStartPrank(actors);
+        executeSymbolicallyAllTargets("check_balanceIntegrityFull_2");
+        vm.stopPrank();
+
+        vaultSoladyBalanceNotBrokenInvarint();
+    }
+
+    function vaultSoladyBalanceNotBrokenInvarint() internal view {
+        /* A regular vault should be able to return all assets */
+        assert(token.getAllShares(address(vaultSolady)) <= usdc.balanceOf(address(vaultSolady)));
+    }
+}

--- a/test/mocks/NonTransferrableRebasingTokenVaultMock.sol
+++ b/test/mocks/NonTransferrableRebasingTokenVaultMock.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.13;
+
+import {NonTransferrableRebasingTokenVault} from "@src/market/token/NonTransferrableRebasingTokenVault.sol";
+
+contract NonTransferrableRebasingTokenVaultMock is NonTransferrableRebasingTokenVault {
+    constructor() {
+        bytes32 slot = _initializableStorageSlot();
+        // re-enables initialize()
+        assembly {
+            sstore(slot, 0)
+        }
+    }
+
+    mapping(address => bool) present_in_shares;
+    mapping(uint256 => address) addresses_with_shares;
+    uint256 number_addresses_with_shares = 0;
+
+    function setSharesOf(address user, uint256 shares) override public onlyAdapter {
+        if (present_in_shares[user] == false)
+        {
+            present_in_shares[user] = true;
+            addresses_with_shares[number_addresses_with_shares] = user;
+            number_addresses_with_shares++;
+        }
+        super.setSharesOf(user, shares);
+    }
+
+    /// @custom:halmos --loop 256
+    function getAllShares(address _vault) external view returns(uint256) {
+        uint256 sum = 0;
+        for (uint256 i = 0; i < number_addresses_with_shares; i++) {
+            address user = addresses_with_shares[i];
+            if (vaultOf[user] == _vault) {
+                sum += sharesOf[user];               
+            }
+        }
+        return sum;
+    }
+
+}


### PR DESCRIPTION
# setup idea overview
The setup is based on the idea that the **NonTransferrableRebasingTokenVault** (`token`) can operate with any `vault`, which can contain literally any implementation, including malicious ones. Therefore, in this setup there are 2 users: **bob** works with the regular **Solady** vault, and the alice works with the Symbolic vault. Both users are given some amount of **USDC**, deposited on `token` account. 
# symbolic vault
To emulate that `vault` can have any implementation, I used the **SymbolicActor** contract from [halmos-helpers-lib](https://github.com/igorganich/halmos-helpers-lib/blob/main/src/SymbolicActor.sol). When someone calls any function from this contract, we enter the `fallback()`, perform some set of transactions internally, and return symbolic bytes. In the case of view functions (`balanceOf()`, `sharesOf()`, etc.) we simply return symbolic bytes.
# Invariant
In these tests, the following invariant was used: we sum all shares of `vaultSolady` contract's users and check if this contract has enough **USDC** balance to repay them. If not - the balance is corrupted and somebody probably can drain the vault. It is worth noting that we do not consider gaining through **yields** in these scenarios.
# Scenarios
Since vulnerabilities `3.1.1` and `3.3.2` have the same essence - an attacker can drain a "valid" vault - it was decided to cover both cases with the same symbolic scenarios and invariants.

In all scenarios we start `prank()` on behalf of a symbolic address. The set of `prank()` addresses is limited to two addresses from the `actors[]` array (**alice** and **bob**). The only difference between these scenarios is a number of covered paths.
## Depth of 1, no reentrancy
The simplest scenario: let's see what we can get if some **user** simply calls some function from **Size**. In this case, **symbolic vault** "does not know how" to handle non-view functions, which means reentrancy will not occur. At the same time, in this scenario, it can handle view functions symbolically.

And this was enough to reproduce vulnerability `3.1.1`: **alice** calls `setUserConfigurationOnBehalfOf()` or `setUserConfiguration()` function with appropriate parameters (while **symbolic vault** returns specific results on view function) and breaks invariant. Analysis of counterexample will be below.
## Depth of 1, reentrancy with depth of 1, NoDuplicateCalls enabled
In this scenario, we add the ability to handle non-view callbacks for the **symbolic vault**: it starts executing one function from **Size** inside of `fallback()`. At the same time, we add the following heuristic: if some function from **Size** has already been called in the current path, we do not call it again.

This scenario is much more "heavy" to execute symbolically, but you can expect it to complete in half a day on a powerful machine.  In addition to the above `3.1.1`, this scenario can detect vulnerability `3.3.2`: after `deposit()`, some symbolic function is called from the **symbolic vault**, which in turn changes the current **vault** of **alice** via `setUserConfigurationOnBehalfOf ` and breaks `shares` of **alice**
## Depth of 1, reentrancy with depth of 1, NoDuplicateCalls disabled
Essentially the same test as above, but this time we turned off the duplicate function heuristic. It can find the same vulnerabilities, but in different scenarios and takes much longer. I couldn't wait for it to finish on my machine.
## Full test
Added all known contract addresses in the `setUp()` as targets, increased the test depth to 2, the recursion depth of fallbacks to 2. Also, callbacks will execute 2 functions inside. I don't think such a test can be done in a reasonable amount of time, but it just shows a possible way to extend the test. Any of the previous tests can be extended further incrementally by adding options from the **Full** test
# Halmos run:
We run halmos with the following parameters:
```javascript
halmos --solver-timeout-assertion 2000 --solver-timeout-branching 2000 --function check_<function_name> --default-bytes-lengths 1024 -vv
```
It has been experimentally shown that giving the solver 2 seconds for **branching** and **assertion** should be enough to find counterexamples and not "hang" when SMT is too complex. Standard values ​​are not suitable for this test.

`--default-bytes-lengths 1024`. This parameter helps to save on the number of paths. The logic of this protocol does not depend on the size of the transmitted byte arrays, so we simply make the assumption that an array bytes of size `1024` should be enough for everything.

`-vv` is used to print full trace of execution path that broke the invariant.
# Counterexamples analysis
```javascript
0xaaaa001c - alice
0xaaaa001d - bob
0xaaaa001e - symbolic vault
0xaaaa0029 - size
0xaaaa002c - adapter
0xaaaa0025 - Underlying token
...
```
## 3.1.1
The full halmos log can be found [here](https://gist.github.com/igorganich/22c2f2e24caf10a18db2abf60a4b6c11)

There are 2 similar counterexamples here, we will only analyze the counterexample with `setUserConfigurationOnBehalfOf()`.
```javascript
Counterexample: 
    halmos_ETH_val_uint256_a531e05_18 = 0x00
    halmos_GlobalStorage_selector_bytes4_17d1c25_19 = 0xc7cd4d87
    halmos_batch_prank_addr_address_ac8301a_16 = 0xaaaa001c
    halmos_check_balanceIntegritySize_address_f29c46d_17 = 0xaaaa0029
    halmos_fallback_is_empty_bool_0b4e934_05 = 0x01
    halmos_fallback_is_empty_bool_494af02_11 = 0x01
    halmos_fallback_is_empty_bool_60d74d5_02 = 0x01
    halmos_fallback_is_empty_bool_ac7c59f_08 = 0x01
    halmos_fallback_is_empty_bool_b6f2233_212 = 0x01
    halmos_fallback_is_empty_bool_d51a2a9_14 = 0x01
    halmos_fallback_retdata_bytes_03ec0f5_12 = 0x80000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
    halmos_fallback_retdata_bytes_4d5326b_06 = 0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffff8000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
    halmos_fallback_retdata_bytes_5c55208_213 = 0x00
    halmos_fallback_retdata_bytes_f359e46_03 = 0xaaaa00220000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
    halmos_fallback_selector_bytes4_18f3654_13 = 0x7a2d13a
    halmos_fallback_selector_bytes4_24e5f0e_10 = 0x70a08231
    halmos_fallback_selector_bytes4_c4fc4f6_04 = 0x70a08231
    halmos_fallback_selector_bytes4_cc57fe9_01 = 0x38d52e0f
    halmos_fallback_selector_bytes4_efaa880_211 = 0x7a2d13a
    halmos_fallback_selector_bytes4_f27dc8f_07 = 0x6e553f65
    p_externalParams.onBehalfOf_address_423501a_196 = 0xaaaa001c
    p_externalParams.params.allCreditPositionsForSaleDisabled_bool_1c01e5f_191 = 0x01
    p_externalParams.params.creditPositionIdsForSale_bool_a65f308_192 = 0x01
    p_externalParams.params.creditPositionIds_length_a988697_193 = 0x00
    p_externalParams.params.openingLimitBorrowCR_uint256_36f3b10_190 = 0x00
    p_externalParams.params.vault_address_a57bb47_189 = 0xaaaa002e
```
Let's look at the key points of symbolic execution that allowed halmos to find a counterexample.
### SetUp() symbolic shares
Take a look to this deposit process of alice:
```solidity
vm.startPrank(alice);
usdc.approve(address(size), USDC_INITIAL_BALANCE);
size.deposit(DepositParams({token: address(usdc), amount: USDC_INITIAL_BALANCE / 2, to: alice}));
...
```
```solidity
function depositOnBehalfOf(DepositOnBehalfOfParams memory params) {
        ...
        state.executeDeposit(params);
    }
```
```solidity
function deposit(address vault, address to, uint256 amount) external onlyOwner returns (uint256 assets) {
        ...
        IERC4626(vault).deposit(amount, address(tokenVault));

        uint256 shares = IERC4626(vault).balanceOf(address(tokenVault)) - vars.sharesBefore;
        tokenVault.setSharesOf(to, vars.userSharesBefore + shares);
    }
```
Let's see how the symbolic vault processed the deposit:
```javascript
[36mCALL[0m ERC1967Proxy::deposit(...) (caller: 0xaaaa001c)
  ...
  [36mDELEGATECALL[0m ERC1967Proxy::executeDeposit(...) (caller: 0xaaaa001c)
  ...
     [36mCALL[0m 0xaaaa0025::deposit(...) (caller: ERC1967Proxy)
  ...
        [36mSTATICCALL[0m 0xaaaa001e::balanceOf(...) (caller: 0xaaaa002c)
        ...
        ↩ RETURN halmos_fallback_retdata_bytes_4d5326b_06
```
As we can see from the logs, **symbolic vault** returned some symbolic value `halmos_fallback_retdata_bytes_4d5326b_06` of **alice's** balance (`balanceOf()` function). **ERC4626Adapter** stored this value as **alice's** current number of `shares`. Let's remember this value.
### Processing setUserConfigurationOnBehalfOf()
During symbolic execution halmos processes all entry points of the target. We will only consider `setUserConfigurationOnBehalfOf()`:
```solidity
function check_BalanceIntegrityNoReentrancy() external {
...
        halmosHelpersSymbolicBatchStartPrank(actors);
        executeSymbolicallyAllTargets("check_balanceIntegritySize");
        vm.stopPrank();
...
```
```javascript
 [36mCALL[0m HalmosSizeTest::check_BalanceIntegrityNoReentrancy() (caller: 0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38)
 ...
    DELEGATECALL[0m ERC1967Proxy::setUserConfigurationOnBehalfOf(Concat(0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000040, p_externalParams.onBehalfOf_address_423501a_196, p_externalParams.params.vault_address_a57bb47_189, p_externalParams.params.openingLimitBorrowCR_uint256_36f3b10_190, p_externalParams.params.allCreditPositionsForSaleDisabled_bool_1c01e5f_191, p_externalParams.params.creditPositionIdsForSale_bool_a65f308_192, 0x00000000000000000000000000000000000000000000000000000000000000a0, p_externalParams.params.creditPositionIds_length_a988697_193, p_externalParams.params.creditPositionIds[0]_uint256_0bb68e8_194, p_externalParams.params.creditPositionIds[1]_uint256_30eb88d_195)) (value: halmos_ETH_val_uint256_a531e05_18) (caller: halmos_batch_prank_addr_address_ac8301a_16)
```   
Before execution, all parameters are symbolic. As validations, constraints, etc. are processed, these symbolic parameters (including the `prank()` address) become more specific. In the counterexample itself, they are all concrete.
### setVault() processing
In one of the paths halmos found the opportunity to do `setVault()`:
```solidity
function setVault(address user, address vault) external onlyMarket {
        ...
            _transferFrom(vaultOf[user], vault, user, user, balanceOf(user));
        ...
            vaultOf[user] = vault;
        }
```
```solidity
function _transferFrom(address vaultFrom, address vaultTo, address from, address to, uint256 value) private {
        if (value > 0) {
            if (vaultFrom == vaultTo) {
                IAdapter adapter = getWhitelistedVaultAdapter(vaultFrom);
                adapter.transferFrom(vaultFrom, from, to, value);
            } else {
                IAdapter adapterFrom = getWhitelistedVaultAdapter(vaultFrom);
                IAdapter adapterTo = getWhitelistedVaultAdapter(vaultTo);
                // slither-disable-next-line unused-return
                adapterFrom.withdraw(vaultFrom, from, address(adapterTo), value);
                // slither-disable-next-line unused-return
                adapterTo.deposit(vaultTo, to, value);
            }
        }
    }
```
Note that the `value` parameter in `_transferFrom()` is the result of the `symbolic_vault::balanceOf()` function. We have seen this pattern before. 

Let's see how halmos handled `setVault()`:
```javascript
[36mCALL[0m 0xaaaa0025::setVault(...) (caller: ERC1967Proxy)
...
    [36mSTATICCALL[0m 0xaaaa002c::balanceOf(...) [static][0m (caller: 0xaaaa0025)
    ...
    RETURN Extract(0x1f3f, 0x1e40, halmos_fallback_retdata_bytes_5c55208_213)
    ...
```
Again `symbolic_vault::balanceOf()` returned the symbolic value `halmos_fallback_retdata_bytes_5c55208_213`. In this particular path halmos considered the possibility that `halmos_fallback_retdata_bytes_5c55208_213 == 0`. And this literally is the condition of the attack `3.1.1`. 

As a result:
1. **Alice's** vault has been changed.
2. `sharesOf[alice]` has not changed anywhere, it is still `halmos_fallback_retdata_bytes_4d5326b_06`. 

### Invariant breaking
At this point, the invariant is easy to break. We know the exact **USDC** balance of `vaultSolady` and we know that `sharesOf[alice]` is a symbolic value that is not constrained by anything. We just need to pick a large enough value and the invariant will be broken. Halmos picked ` halmos_fallback_retdata_bytes_4d5326b_06 = 0x7ffffffffffffffffffffffffffffffffffffffffffffffffffffff80000......000`. 

Vulnerability reproduced!
## 3.3.2
The essence of the `3.2.2` vulnerability reproduction is very similar to `3.1.1`, but there is a key difference: You need to use a test with support for callbacks by **symbolic vault**. 

We will consider [part of the log](https://gist.github.com/igorganich/069fda8de9a5e2b76134f40b6f3ab68c) that is generated by running the test function `check_BalanceIntegrityWithReentrancyNoDuplicateCallsEnabled()`. The full log is too large, overloaded, and there is no point in looking at all the duplicate counterexamples.

```javascript
halmos_ETH_val_uint256_4a429ed_18 = 0x00
    halmos_ETH_val_uint256_ecad954_218 = 0x00
    halmos_GlobalStorage_selector_bytes4_461be31_219 = 0xc7cd4d87
    halmos_GlobalStorage_selector_bytes4_6b4cf9d_19 = 0xcf8542f
    halmos_batch_prank_addr_address_afc9ae3_16 = 0xaaaa001d
    halmos_check_balanceIntegritySize_address_7f97a89_17 = 0xaaaa0029
    halmos_fallback_is_empty_bool_0075bcd_14 = 0x01
    halmos_fallback_is_empty_bool_528c080_419 = 0x01
    halmos_fallback_is_empty_bool_67e14d2_212 = 0x01
    halmos_fallback_is_empty_bool_6e19cf6_11 = 0x01
    halmos_fallback_is_empty_bool_6e5ce5f_412 = 0x01
    halmos_fallback_is_empty_bool_7235517_08 = 0x01
    halmos_fallback_is_empty_bool_9993aba_416 = 0x01
    halmos_fallback_is_empty_bool_a9b682a_215 = 0x00
    halmos_fallback_is_empty_bool_ba35b42_05 = 0x01
    halmos_fallback_is_empty_bool_c4b65bc_02 = 0x01
    halmos_fallback_is_revert_bool_18b5a3d_216 = 0x00
    halmos_fallback_retdata_bytes_471ae07_06 = 0x00
    halmos_fallback_retdata_bytes_6887436_417 = 0x80000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
    halmos_fallback_retdata_bytes_95474c5_413 = 0x00
    halmos_fallback_retdata_bytes_bca175b_213 = 0x00
    halmos_fallback_retdata_bytes_d499086_03 = 0xaaaa00220000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
    halmos_fallback_retdata_bytes_db6c3da_12 = 0x00
    halmos_fallback_selector_bytes4_136534d_415 = 0x70a08231
    halmos_fallback_selector_bytes4_13679f1_411 = 0x7a2d13a
    halmos_fallback_selector_bytes4_52d88c6_418 = 0x7a2d13a
    halmos_fallback_selector_bytes4_5753c58_211 = 0x70a08231
    halmos_fallback_selector_bytes4_9786b66_214 = 0x6e553f65
    halmos_fallback_selector_bytes4_986e829_10 = 0x70a08231
    halmos_fallback_selector_bytes4_a34164a_07 = 0x6e553f65
    halmos_fallback_selector_bytes4_b04bf0b_13 = 0x7a2d13a
    halmos_fallback_selector_bytes4_b5a0882_04 = 0x70a08231
    halmos_fallback_selector_bytes4_fd18221_01 = 0x38d52e0f
    halmos_fallback_target_address_dd71d4b_217 = 0xaaaa0029
    p_externalParams.onBehalfOf_address_d4dce10_396 = 0xaaaa001c
    p_externalParams.params.allCreditPositionsForSaleDisabled_bool_e868154_391 = 0x01
    p_externalParams.params.creditPositionIdsForSale_bool_72f6795_392 = 0x01
    p_externalParams.params.creditPositionIds_length_8bf027a_393 = 0x00
    p_externalParams.params.openingLimitBorrowCR_uint256_8c33c38_390 = 0x00
    p_externalParams.params.vault_address_8ab8556_389 = 0xaaaa002e
    p_params.amount_uint256_ccf4925_91 = 0x4000000000
    p_params.to_address_fedf92e_92 = 0xaaaa001c
    p_params.token_address_0249170_90 = 0xaaaa0022
```
Let's look at the key points of symbolic execution that allowed halmos to find a counterexample.
### deposit symbolic processing
In this case, halmos began his journey to a counterexample with `Size::deposit()`:
```solidity
function check_BalanceIntegrityWithReentrancyNoDuplicateCallsEnabled() external {
    ...
    halmosHelpersSymbolicBatchStartPrank(actors);
    executeSymbolicallyAllTargets("check_balanceIntegritySize");
    vm.stopPrank();
```
```javascript
...
CALL ERC1967Proxy::deposit(Concat(p_params.token_address_0249170_90, p_params.amount_uint256_ccf4925_91, p_params.to_address_fedf92e_92)) (caller: halmos_batch_prank_addr_address_afc9ae3_16)
...
```
So far, all parameters and even `caller` are symbolic values.
```solidity
function depositOnBehalfOf(DepositOnBehalfOfParams memory params) {
    ...
    state.executeDeposit(params);
}
```
```solidity
function executeDeposit(State storage state, DepositOnBehalfOfParams memory externalParams) public {
    ...
    amount = state.data.borrowTokenVault.deposit(params.to, amount);
}
```
```solidity
function deposit(address to, uint256 amount) external onlyMarket returns (uint256 assets) {
    ...
    assets = adapter.deposit(vaultOf[to], to, amount);
    ...
}
```
```javascript
DELEGATECALL ERC1967Proxy::executeDeposit(..., halmos_batch_prank_addr_address_afc9ae3_16)(caller: halmos_batch_prank_addr_address_afc9ae3_16)
...
    CALL 0xaaaa0025::deposit(...) (caller: ERC1967Proxy)
    ...
        CALL 0xaaaa002c::deposit(...) (caller: 0xaaaa0025)
```
### external calls to symbolic vault in deposit()
```solidity
function deposit(address vault, address to, uint256 amount) external onlyOwner returns (uint256 assets) {
    // slither-disable-next-line uninitialized-local
    Vars memory vars;
    vars.sharesBefore = IERC4626(vault).balanceOf(address(tokenVault));
    vars.userSharesBefore = tokenVault.sharesOf(to);

    underlyingToken.forceApprove(vault, amount);
    // slither-disable-next-line unused-return
    IERC4626(vault).deposit(amount, address(tokenVault));

    uint256 shares = IERC4626(vault).balanceOf(address(tokenVault)) - vars.sharesBefore;
    assets = IERC4626(vault).convertToAssets(shares);

    tokenVault.setSharesOf(to, vars.userSharesBefore + shares);
}
```
This place is the critical point of the entire attack. Here we have 4 external calls to the **symbolic vault**:
1. view functions (`balanceOf()`, `convertToAssets()`). We already know that they return a symbolic unbounded value. We are only interested in:
```solidity
vars.sharesBefore = IERC4626(vault).balanceOf(address(tokenVault));
vars.userSharesBefore = tokenVault.sharesOf(to);
...
uint256 shares = IERC4626(vault).balanceOf(address(tokenVault)) - vars.sharesBefore;
...
tokenVault.setSharesOf(to, vars.userSharesBefore + shares);
```
It's not hard to guess that `tokenVault.setSharesOf()` will take a symbolic value, completely controlled by what the **symbolic vault** returned.
2. non-view `deposit()` function. Inside it does reentrancy and sets up another `vault` for **alice**. We will discuss this in more detail in the next section.
### symbolic vault reentrancy processing
If the `fallback()` processing depth is enabled at least `1`, the **symbolic vault** will start making external calls to all targets (in this case, only **Size**).
```solidity
contract SymbolicActor is HalmosHelpersTargetsExecutor {
    ...
    fallback() external payable {
        ...
        for (uint8 i = 0; i < symbolic_fallback_txs_number; i++) {
            ...
            executeSymbolicallyAllTargets("fallback_target");
            ...
        }
        ...
    }
}
```
And in this path, it executed a symbolic call to the `setUserConfigurationOnBehalfOf()` function, changing **alice's** `vault` to `vaultSolady`. We have already discussed the mechanics of processing such a symbolic call above, so I will not dwell on it.
```javascript
CALL 0xaaaa001e::deposit(...) (caller: 0xaaaa002c)
...
    CALL ERC1967Proxy::setUserConfigurationOnBehalfOf(...) (caller: 0xaaaa001e)
    ...
```

At this stage, we have met all the conditions for a broken invariant: the sum of all shares in `vaultSolady` far exceeds its `balance`.

This vulnerability is reproduced as well.